### PR TITLE
Revert namespace from Itineris back to DanLapteacru

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Create, register, and reuse [FacetWP](https://facetwp.com/) plugin facets/templates using PHP, and keep them in your source code repository. To read more about registering FacetWP facets and templates via PHP, go here: [facets documentation](https://facetwp.com/help-center/developers/hooks/advanced-hooks/facetwp_facets/) and [templates documentation](https://facetwp.com/help-center/developers/hooks/advanced-hooks/facetwp_templates/).
 
-[![Packagist Version](https://img.shields.io/packagist/v/itinerisltd/facetwp-builder.svg?label=release&style=flat-square)](https://packagist.org/packages/itinerisltd/facetwp-builder)
-[![PHP from Packagist](https://img.shields.io/packagist/php-v/itinerisltd/facetwp-builder.svg?style=flat-square)](https://packagist.org/packages/itinerisltd/facetwp-builder)
-[![Packagist Downloads](https://img.shields.io/packagist/dt/itinerisltd/facetwp-builder.svg?label=packagist%20downloads&style=flat-square)](https://packagist.org/packages/itinerisltd/facetwp-builder/stats)
-[![GitHub License](https://img.shields.io/github/license/itinerisltd/facetwp-builder.svg?style=flat-square)](https://github.com/itinerisltd/facetwp-builder/blob/master/LICENSE)
+[![Packagist Version](https://img.shields.io/packagist/v/danlapteacru/facetwp-builder.svg?label=release&style=flat-square)](https://packagist.org/packages/danlapteacru/facetwp-builder)
+[![PHP from Packagist](https://img.shields.io/packagist/php-v/danlapteacru/facetwp-builder.svg?style=flat-square)](https://packagist.org/packages/danlapteacru/facetwp-builder)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/danlapteacru/facetwp-builder.svg?label=packagist%20downloads&style=flat-square)](https://packagist.org/packages/danlapteacru/facetwp-builder/stats)
+[![GitHub License](https://img.shields.io/github/license/danlapteacru/facetwp-builder.svg?style=flat-square)](https://github.com/danlapteacru/facetwp-builder/blob/master/LICENSE)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -30,7 +30,7 @@ Create, register, and reuse [FacetWP](https://facetwp.com/) plugin facets/templa
 ## Installation
 
 ```bash
-composer require itinerisltd/facetwp-builder
+composer require danlapteacru/facetwp-builder
 ```
 
 If your project isn't using composer, you can require the `autoload.php` file.
@@ -482,30 +482,30 @@ $builder->addFacet('my_facet', 'checkbox', [
 ]);
 ```
 
-To use a type not in the built-in [`ALLOWED_FACET_TYPES`](https://github.com/itinerisltd/facetwp-builder/blob/main/src/FacetsBuilder.php#L66) constant, register it via the [`itinerisltd/facetwp-builder/allowed_facet_types`](#itinerisltdfacetwp-builderallowed_facet_types) filter hook.
+To use a type not in the built-in [`ALLOWED_FACET_TYPES`](https://github.com/danlapteacru/facetwp-builder/blob/main/src/FacetsBuilder.php#L66) constant, register it via the [`danlapteacru/facetwp-builder/allowed_facet_types`](#danlapteacrufacetwp-builderallowed_facet_types) filter hook.
 
 ## Hooks
 
-### `itinerisltd/facetwp-builder/allowed_facet_types`
+### `danlapteacru/facetwp-builder/allowed_facet_types`
 
 Filter the list of allowed facet types. Use this to add support for custom or 3rd-party addon types.
 
 ```php
-add_filter('itinerisltd/facetwp-builder/allowed_facet_types', function (array $types): array {
+add_filter('danlapteacru/facetwp-builder/allowed_facet_types', function (array $types): array {
     $types[] = 'my_custom_type';
     return $types;
 });
 ```
 
-### `itinerisltd/facetwp-builder/facets`
+### `danlapteacru/facetwp-builder/facets`
 
 Filter the compiled facets array before it is returned by `FacetsBuilder::build()`.
 
-### `itinerisltd/facetwp-builder/facet_key`
+### `danlapteacru/facetwp-builder/facet_key`
 
 Filter the resolved facet type key before it is validated inside `FacetsBuilder::__call()`. Useful for aliasing method names to custom type strings.
 
-### `itinerisltd/facetwp-builder/templates`
+### `danlapteacru/facetwp-builder/templates`
 
 Filter the compiled templates array before it is returned by `TemplatesBuilder::build()`.
 
@@ -522,7 +522,7 @@ Filter the compiled templates array before it is returned by `TemplatesBuilder::
 ### Add Facets
 
 ```php
-use Itineris\FacetWpBuilder\FacetsBuilder;
+use DanLapteacru\FacetWpBuilder\FacetsBuilder;
 
 $builder = new FacetsBuilder();
 $builder
@@ -536,9 +536,9 @@ $builder->build();
 ### Add a custom facet
 
 ```php
-use Itineris\FacetWpBuilder\FacetBuilder;
-use Itineris\FacetWpBuilder\Facets\Checkbox;
-use Itineris\FacetWpBuilder\FacetsBuilder;
+use DanLapteacru\FacetWpBuilder\FacetBuilder;
+use DanLapteacru\FacetWpBuilder\Facets\Checkbox;
+use DanLapteacru\FacetWpBuilder\FacetsBuilder;
 
 $facet = new FacetBuilder('my_facet', Checkbox::TYPE);
 $facet
@@ -552,7 +552,7 @@ FacetsBuilder::addFacetWpHook($facetArray);
 ### Add Template
 
 ```php
-use Itineris\FacetWpBuilder\TemplatesBuilder;
+use DanLapteacru\FacetWpBuilder\TemplatesBuilder;
 
 $builder = new TemplatesBuilder();
 $builder
@@ -570,10 +570,10 @@ $builder->build();
 
 ## Credits
 
-[FacetWP Builder](https://github.com/itinerisltd/facetwp-builder) is maintained by [Itineris](https://www.itineris.co.uk/), originally created by [Dan Lapteacru](https://github.com/danlapteacru).
+[FacetWP Builder](https://github.com/danlapteacru/facetwp-builder) is created and maintained by [Dan Lapteacru](https://github.com/danlapteacru).
 
-Full list of contributors can be found [here](https://github.com/itinerisltd/facetwp-builder/graphs/contributors).
+Full list of contributors can be found [here](https://github.com/danlapteacru/facetwp-builder/graphs/contributors).
 
 ## License
 
-[FacetWP Builder](https://github.com/itinerisltd/facetwp-builder) is released under the [MIT License](https://opensource.org/licenses/MIT).
+[FacetWP Builder](https://github.com/danlapteacru/facetwp-builder) is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "itinerisltd/facetwp-builder",
+  "name": "danlapteacru/facetwp-builder",
   "description": "An Advanced FacetWP Builder for facets and templates.",
   "license": "MIT",
   "type": "package",
@@ -10,11 +10,11 @@
       "role": "Developer"
     }
   ],
-  "homepage": "https://github.com/itinerisltd/facetwp-builder/",
+  "homepage": "https://github.com/danlapteacru/facetwp-builder/",
   "support": {
     "email": "danlapteacru@gmail.com",
-    "issues": "https://github.com/itinerisltd/facetwp-builder/issues",
-    "source": "https://github.com/itinerisltd/facetwp-builder"
+    "issues": "https://github.com/danlapteacru/facetwp-builder/issues",
+    "source": "https://github.com/danlapteacru/facetwp-builder"
   },
   "require": {
     "php": "^8.1",
@@ -23,7 +23,7 @@
   "prefer-stable": true,
   "autoload": {
     "psr-4": {
-      "Itineris\\FacetWpBuilder\\": "src/"
+      "DanLapteacru\\FacetWpBuilder\\": "src/"
     }
   },
   "config": {

--- a/src/Abstracts/Facet.php
+++ b/src/Abstracts/Facet.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Abstracts;
+namespace DanLapteacru\FacetWpBuilder\Abstracts;
 
 /**
  * Facet type.

--- a/src/Abstracts/FacetWpManager.php
+++ b/src/Abstracts/FacetWpManager.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Abstracts;
+namespace DanLapteacru\FacetWpBuilder\Abstracts;
 
-use Itineris\FacetWpBuilder\Exceptions\FacetNameCollisionException;
-use Itineris\FacetWpBuilder\Exceptions\FacetNotFoundException;
-use Itineris\FacetWpBuilder\FacetBuilder;
-use Itineris\FacetWpBuilder\TemplateBuilder;
+use DanLapteacru\FacetWpBuilder\Exceptions\FacetNameCollisionException;
+use DanLapteacru\FacetWpBuilder\Exceptions\FacetNotFoundException;
+use DanLapteacru\FacetWpBuilder\FacetBuilder;
+use DanLapteacru\FacetWpBuilder\TemplateBuilder;
 use OutOfRangeException;
 
 /**

--- a/src/Abstracts/ParentDelegationBuilder.php
+++ b/src/Abstracts/ParentDelegationBuilder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Abstracts;
+namespace DanLapteacru\FacetWpBuilder\Abstracts;
 
-use Itineris\FacetWpBuilder\Interfaces\Builder;
+use DanLapteacru\FacetWpBuilder\Interfaces\Builder;
 
 /**
  * Builds a configuration.

--- a/src/Exceptions/FacetNameCollisionException.php
+++ b/src/Exceptions/FacetNameCollisionException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Exceptions;
+namespace DanLapteacru\FacetWpBuilder\Exceptions;
 
 /**
  * Thrown when a sibling facet name already exists in a Builder

--- a/src/Exceptions/FacetNotFoundException.php
+++ b/src/Exceptions/FacetNotFoundException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Exceptions;
+namespace DanLapteacru\FacetWpBuilder\Exceptions;
 
 /**
  * Thrown when a facet is not found on a Builder by a supplied name

--- a/src/FacetBuilder.php
+++ b/src/FacetBuilder.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder;
+namespace DanLapteacru\FacetWpBuilder;
 
 use BadMethodCallException;
-use Itineris\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
-use Itineris\FacetWpBuilder\Interfaces\Builder;
-use Itineris\FacetWpBuilder\Interfaces\NamedBuilder;
-use Itineris\FacetWpBuilder\Traits\Builder as BuilderTrait;
-use Itineris\FacetWpBuilder\Traits\Helpers;
+use DanLapteacru\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
+use DanLapteacru\FacetWpBuilder\Interfaces\Builder;
+use DanLapteacru\FacetWpBuilder\Interfaces\NamedBuilder;
+use DanLapteacru\FacetWpBuilder\Traits\Builder as BuilderTrait;
+use DanLapteacru\FacetWpBuilder\Traits\Helpers;
 
 /**
  * Builds configurations for an FacetWP facet.

--- a/src/FacetManager.php
+++ b/src/FacetManager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder;
+namespace DanLapteacru\FacetWpBuilder;
 
-use Itineris\FacetWpBuilder\Abstracts\FacetWpManager;
+use DanLapteacru\FacetWpBuilder\Abstracts\FacetWpManager;
 
 class FacetManager extends FacetWpManager
 {

--- a/src/Facets/Autocomplete.php
+++ b/src/Facets/Autocomplete.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Autocomplete Facet type.

--- a/src/Facets/Checkbox.php
+++ b/src/Facets/Checkbox.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Checkbox Facet type.

--- a/src/Facets/DateRange.php
+++ b/src/Facets/DateRange.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Date Range Facet type.

--- a/src/Facets/Dropdown.php
+++ b/src/Facets/Dropdown.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Dropdown Facet type.

--- a/src/Facets/FSelect.php
+++ b/src/Facets/FSelect.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * FSelect Facet type.

--- a/src/Facets/Hierarchy.php
+++ b/src/Facets/Hierarchy.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Hierarchy Facet type.

--- a/src/Facets/NumberRange.php
+++ b/src/Facets/NumberRange.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Number Range Facet type.

--- a/src/Facets/Pager.php
+++ b/src/Facets/Pager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Pager Facet type.

--- a/src/Facets/Proximity.php
+++ b/src/Facets/Proximity.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Proximity Facet type.

--- a/src/Facets/Radio.php
+++ b/src/Facets/Radio.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Radio Facet type.

--- a/src/Facets/Reset.php
+++ b/src/Facets/Reset.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Reset Facet type.

--- a/src/Facets/Search.php
+++ b/src/Facets/Search.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Search Facet type.

--- a/src/Facets/Slider.php
+++ b/src/Facets/Slider.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Slider Facet type.

--- a/src/Facets/Sort.php
+++ b/src/Facets/Sort.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Sort Facet type.

--- a/src/Facets/StarRating.php
+++ b/src/Facets/StarRating.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * Star Rating Facet type.

--- a/src/Facets/UserSelections.php
+++ b/src/Facets/UserSelections.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Facets;
+namespace DanLapteacru\FacetWpBuilder\Facets;
 
-use Itineris\FacetWpBuilder\Abstracts\Facet;
+use DanLapteacru\FacetWpBuilder\Abstracts\Facet;
 
 /**
  * User Selection Facet type.

--- a/src/FacetsBuilder.php
+++ b/src/FacetsBuilder.php
@@ -2,29 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder;
+namespace DanLapteacru\FacetWpBuilder;
 
 use BadMethodCallException;
-use Itineris\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
-use Itineris\FacetWpBuilder\Facets\Autocomplete;
-use Itineris\FacetWpBuilder\Facets\Checkbox;
-use Itineris\FacetWpBuilder\Facets\DateRange;
-use Itineris\FacetWpBuilder\Facets\Dropdown;
-use Itineris\FacetWpBuilder\Facets\FSelect;
-use Itineris\FacetWpBuilder\Facets\Hierarchy;
-use Itineris\FacetWpBuilder\Facets\NumberRange;
-use Itineris\FacetWpBuilder\Facets\Pager;
-use Itineris\FacetWpBuilder\Facets\Proximity;
-use Itineris\FacetWpBuilder\Facets\Radio;
-use Itineris\FacetWpBuilder\Facets\Reset;
-use Itineris\FacetWpBuilder\Facets\Search;
-use Itineris\FacetWpBuilder\Facets\Slider;
-use Itineris\FacetWpBuilder\Facets\Sort;
-use Itineris\FacetWpBuilder\Facets\StarRating;
-use Itineris\FacetWpBuilder\Facets\UserSelections;
-use Itineris\FacetWpBuilder\Interfaces\Builder;
-use Itineris\FacetWpBuilder\Interfaces\NamedBuilder;
-use Itineris\FacetWpBuilder\Traits\Helpers;
+use DanLapteacru\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
+use DanLapteacru\FacetWpBuilder\Facets\Autocomplete;
+use DanLapteacru\FacetWpBuilder\Facets\Checkbox;
+use DanLapteacru\FacetWpBuilder\Facets\DateRange;
+use DanLapteacru\FacetWpBuilder\Facets\Dropdown;
+use DanLapteacru\FacetWpBuilder\Facets\FSelect;
+use DanLapteacru\FacetWpBuilder\Facets\Hierarchy;
+use DanLapteacru\FacetWpBuilder\Facets\NumberRange;
+use DanLapteacru\FacetWpBuilder\Facets\Pager;
+use DanLapteacru\FacetWpBuilder\Facets\Proximity;
+use DanLapteacru\FacetWpBuilder\Facets\Radio;
+use DanLapteacru\FacetWpBuilder\Facets\Reset;
+use DanLapteacru\FacetWpBuilder\Facets\Search;
+use DanLapteacru\FacetWpBuilder\Facets\Slider;
+use DanLapteacru\FacetWpBuilder\Facets\Sort;
+use DanLapteacru\FacetWpBuilder\Facets\StarRating;
+use DanLapteacru\FacetWpBuilder\Facets\UserSelections;
+use DanLapteacru\FacetWpBuilder\Interfaces\Builder;
+use DanLapteacru\FacetWpBuilder\Interfaces\NamedBuilder;
+use DanLapteacru\FacetWpBuilder\Traits\Helpers;
 
 /**
  * Builds configurations for FaceWP facets
@@ -51,7 +51,7 @@ use Itineris\FacetWpBuilder\Traits\Helpers;
  * @method FacetsBuilder addUserSelections(string $name, array $args = [])
  *
  * @information To add a custom facet type, you can use the addFacet() method or use the
- * "itinerisltd/facetwp-builder/facets" WP filter.
+ * "danlapteacru/facetwp-builder/facets" WP filter.
  */
 class FacetsBuilder extends ParentDelegationBuilder implements NamedBuilder
 {
@@ -136,7 +136,7 @@ class FacetsBuilder extends ParentDelegationBuilder implements NamedBuilder
         $facets = $this->buildFacets();
         if (function_exists('apply_filters')) {
             $facets = apply_filters(
-                'itinerisltd/facetwp-builder/facets',
+                'danlapteacru/facetwp-builder/facets',
                 $facets,
                 $this,
             );
@@ -226,7 +226,7 @@ class FacetsBuilder extends ParentDelegationBuilder implements NamedBuilder
 
         if (function_exists('apply_filters')) {
             $facetTypes = apply_filters(
-                'itinerisltd/facetwp-builder/allowed_facet_types',
+                'danlapteacru/facetwp-builder/allowed_facet_types',
                 $facetTypes,
             );
         }
@@ -252,7 +252,7 @@ class FacetsBuilder extends ParentDelegationBuilder implements NamedBuilder
 
         if (function_exists('apply_filters')) {
             $keyName = apply_filters(
-                'itinerisltd/facetwp-builder/facet_key',
+                'danlapteacru/facetwp-builder/facet_key',
                 $keyName,
                 $methodName,
                 $method,

--- a/src/Interfaces/Builder.php
+++ b/src/Interfaces/Builder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Interfaces;
+namespace DanLapteacru\FacetWpBuilder\Interfaces;
 
 /**
  * Interface for Builder

--- a/src/Interfaces/NamedBuilder.php
+++ b/src/Interfaces/NamedBuilder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Interfaces;
+namespace DanLapteacru\FacetWpBuilder\Interfaces;
 
 /**
  * Builder with a name

--- a/src/TemplateBuilder.php
+++ b/src/TemplateBuilder.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace DanLapteacru\FacetWpBuilder;
 
-use Exception;
 use DanLapteacru\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
 use DanLapteacru\FacetWpBuilder\Interfaces\Builder;
 use DanLapteacru\FacetWpBuilder\Interfaces\NamedBuilder;
 use DanLapteacru\FacetWpBuilder\Traits\Builder as BuilderTrait;
 use DanLapteacru\FacetWpBuilder\Traits\Helpers;
+use Exception;
 use WP_Post_Type;
 
 /**

--- a/src/TemplateBuilder.php
+++ b/src/TemplateBuilder.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder;
+namespace DanLapteacru\FacetWpBuilder;
 
 use Exception;
-use Itineris\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
-use Itineris\FacetWpBuilder\Interfaces\Builder;
-use Itineris\FacetWpBuilder\Interfaces\NamedBuilder;
-use Itineris\FacetWpBuilder\Traits\Builder as BuilderTrait;
-use Itineris\FacetWpBuilder\Traits\Helpers;
+use DanLapteacru\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
+use DanLapteacru\FacetWpBuilder\Interfaces\Builder;
+use DanLapteacru\FacetWpBuilder\Interfaces\NamedBuilder;
+use DanLapteacru\FacetWpBuilder\Traits\Builder as BuilderTrait;
+use DanLapteacru\FacetWpBuilder\Traits\Helpers;
 use WP_Post_Type;
 
 /**

--- a/src/TemplateManager.php
+++ b/src/TemplateManager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder;
+namespace DanLapteacru\FacetWpBuilder;
 
-use Itineris\FacetWpBuilder\Abstracts\FacetWpManager;
+use DanLapteacru\FacetWpBuilder\Abstracts\FacetWpManager;
 
 class TemplateManager extends FacetWpManager
 {

--- a/src/TemplatesBuilder.php
+++ b/src/TemplatesBuilder.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder;
+namespace DanLapteacru\FacetWpBuilder;
 
-use Itineris\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
-use Itineris\FacetWpBuilder\Interfaces\Builder;
-use Itineris\FacetWpBuilder\Interfaces\NamedBuilder;
-use Itineris\FacetWpBuilder\Traits\Helpers;
+use DanLapteacru\FacetWpBuilder\Abstracts\ParentDelegationBuilder;
+use DanLapteacru\FacetWpBuilder\Interfaces\Builder;
+use DanLapteacru\FacetWpBuilder\Interfaces\NamedBuilder;
+use DanLapteacru\FacetWpBuilder\Traits\Helpers;
 
 /**
  * Builds configurations for FaceWP templates.
@@ -72,7 +72,7 @@ class TemplatesBuilder extends ParentDelegationBuilder implements NamedBuilder
         $facets = $this->buildTemplates();
         if (function_exists('apply_filters')) {
             $facets = apply_filters(
-                'itinerisltd/facetwp-builder/templates',
+                'danlapteacru/facetwp-builder/templates',
                 $facets,
                 $this,
             );

--- a/src/Traits/Builder.php
+++ b/src/Traits/Builder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Traits;
+namespace DanLapteacru\FacetWpBuilder\Traits;
 
 /**
  * Builder trait.

--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Itineris\FacetWpBuilder\Traits;
+namespace DanLapteacru\FacetWpBuilder\Traits;
 
 trait Helpers
 {


### PR DESCRIPTION
## Summary

- Reverts the PHP namespace from `Itineris\FacetWpBuilder` back to `DanLapteacru\FacetWpBuilder` across all 31 source files
- Updates `composer.json`: package name, homepage, support URLs, and PSR-4 autoload namespace
- Updates `README.md`: badges, composer require command, code examples, WordPress filter hook names, and credits section
- Renames all WordPress filter hooks from `itinerisltd/facetwp-builder/*` to `danlapteacru/facetwp-builder/*`

## Test plan

- [ ] Run `composer dump-autoload` and verify no errors
- [ ] Verify all classes are autoloaded correctly with the new namespace
- [ ] Confirm filter hooks work with the updated names